### PR TITLE
Removing print statement from init method

### DIFF
--- a/Sources/AVLTree.swift
+++ b/Sources/AVLTree.swift
@@ -48,7 +48,6 @@ internal class AVLTree<ValueType: Comparable>: ExpressibleByArrayLiteral {
         for value in values {
             self.insert(value: value)
         }
-        print(self)
     }
 
     ///


### PR DESCRIPTION
Removing print (was using during development) statement from init method.